### PR TITLE
Add fixes for generate

### DIFF
--- a/models/llama3/tests/api/test_generation.py
+++ b/models/llama3/tests/api/test_generation.py
@@ -10,6 +10,8 @@ import unittest
 
 from pathlib import Path
 
+import torch
+
 import numpy as np
 from llama_models.llama3.api.datatypes import ImageMedia, SystemMessage, UserMessage
 
@@ -34,6 +36,7 @@ def build_generator(env_var: str):
         max_seq_len=128,
         max_batch_size=1,
         model_parallel_size=1,
+        device=torch.device(os.getenv("DEVICE", "cuda"))
     )
 
 


### PR DESCRIPTION
@anordin95 : These are fixes I've made against https://github.com/meta-llama/llama-models/pull/165 on my side to make this test running for me:
* `models/llama3/tests/api/test_generation.py::TestTextModelInference::test_run_generation`

I deliberately omitted 1 fix which we debate in one of the comments - the need to call `.to(device)`. It is needed on my side and I am calling it in line 163 in the end of the `build()`. To run the tests:
```
TEXT_MODEL_CHECKPOINT_DIR=/home/dvrogozh/huggingface/meta-llama/Meta-Llama-3.1-8B-Instruct/ \
DEVICE=xpu \
python -m pytest --pspec \
  models/llama3/tests/api/test_generation.py::TestTextModelInference::test_run_generation
```